### PR TITLE
Allow Yeoman and other automated task managers to pull css file as well.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "blackgate"
   ],
   "description": "Simple pane splitter for angular.js",
-  "main": "js/splitter.js",
+  "main": ["js/splitter.js", "css/style.css"],
   "keywords": [
     "splitter",
     "angularjs",


### PR DESCRIPTION
When grunt builds an angular project, it uses main to determine which files to include in the build.  If we don't include the css file in main, then it'll be missing when the project is built, so the panes won't work.